### PR TITLE
feat(cmp): add optional cmp kind configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ Example:
 
 ![cmp-natdat completions in the nvim-cmp popup are labeled "NatDat" in red](https://github.com/Gelio/cmp-natdat/assets/889383/52730df8-e355-4f4e-842f-d4cb283fbb12)
 
+To get the most out of the custom cmp kind text, you can also use
+[lspkind.nvim](https://github.com/onsails/lspkind.nvim) to show the calendar
+icon (📆) for cmp-natdat completions:
+
+```lua
+require("lspkind").init({
+    symbol_map = {
+        NatDat = "📅",
+    },
+})
+```
+
+![cmp-natdat completions use the calendar icon](https://github.com/Gelio/cmp-natdat/assets/889383/9bf4df4c-fdfb-44d7-a60f-2a8370c94935)
+
 ## WARNING: cool tech inside
 
 Parsing the dates is done using [pcomb](./lua/pcomb/), a Lua parser combinator

--- a/README.md
+++ b/README.md
@@ -59,6 +59,37 @@ https://github.com/Gelio/cmp-natdat/assets/889383/1d6d388d-2a10-4923-9156-b99764
    }
    ```
 
+## Configuration (optional)
+
+`cmp-natdat` accepts the following optional configuration, passed as a table to
+the `setup()` method:
+
+- `cmp_kind_text` - the text to use as the completion item's label in the
+  nvim-cmp completions popup.
+
+  Default: `Text`
+
+- `highlight_group` - the name of an existing highlight group to use for that
+  completion item's label in the nvim-cmp completions popup.
+
+  Default: `CmpItemKindText`
+
+Example:
+
+```lua
+{
+    "Gelio/cmp-natdat",
+    config = function()
+        require("cmp_natdat").setup({
+            cmp_kind_text = "NatDat",
+            highlight_group = "Red",
+        })
+    end,
+}
+```
+
+![cmp-natdat completions in the nvim-cmp popup are labeled "NatDat" in red](https://github.com/Gelio/cmp-natdat/assets/889383/52730df8-e355-4f4e-842f-d4cb283fbb12)
+
 ## WARNING: cool tech inside
 
 Parsing the dates is done using [pcomb](./lua/pcomb/), a Lua parser combinator

--- a/lua/cmp_natdat/common.lua
+++ b/lua/cmp_natdat/common.lua
@@ -1,0 +1,3 @@
+return {
+	COMPLETION_HIGHLIGHT_GROUP = "CmpItemKindNatDat",
+}

--- a/lua/cmp_natdat/config.lua
+++ b/lua/cmp_natdat/config.lua
@@ -1,0 +1,22 @@
+---cmp_natdat configuration accepted by the .setup() function.
+---@class cmp_natdat.Config
+---An existing highlight group to use for the cmp_natdat completions in the
+---nvim-cmp popup
+---@field highlight_group string?
+---Text to use for the labels of cmp_natdat completions in the nvim-cmp popup
+---@field cmp_kind_text string?
+
+---Full cmp_natdat configuration
+---@class cmp_natdat.FullConfig
+---@field highlight_group string
+---@field cmp_kind_text string
+
+---@type cmp_natdat.FullConfig
+local default_config = {
+	highlight_group = "CmpItemKindText",
+	cmp_kind_text = "Text",
+}
+
+return {
+	default = default_config,
+}

--- a/lua/cmp_natdat/init.lua
+++ b/lua/cmp_natdat/init.lua
@@ -1,7 +1,35 @@
 local M = {}
 
-function M.setup()
-	require("cmp").register_source("natdat", require("cmp_natdat.source").new())
+local cmp_natdat_common = require("cmp_natdat.common")
+local cmp_natdat_config = require("cmp_natdat.config")
+
+---@param highlight_group string
+local function set_completion_highlight_group(highlight_group)
+	local GLOBAL_HIGHLIGHT_NAMESPACE = 0
+
+	vim.api.nvim_set_hl(
+		GLOBAL_HIGHLIGHT_NAMESPACE,
+		cmp_natdat_common.COMPLETION_HIGHLIGHT_GROUP,
+		{ link = highlight_group }
+	)
+end
+
+---@param config cmp_natdat.Config?
+function M.setup(config)
+	config = config or {}
+
+	---@type cmp_natdat.FullConfig
+	local full_config = vim.tbl_extend("force", cmp_natdat_config.default, config)
+
+	set_completion_highlight_group(full_config.highlight_group)
+
+	---@type lsp.internal.CmpCompletionExtension
+	local cmp_completion_extension = {
+		kind_text = full_config.cmp_kind_text,
+		kind_hl_group = cmp_natdat_common.COMPLETION_HIGHLIGHT_GROUP,
+	}
+
+	require("cmp").register_source("natdat", require("cmp_natdat.source").new(cmp_completion_extension))
 end
 
 return M


### PR DESCRIPTION
Allow changing this source cmp completions' kind text and highlight group by providing options to the plugin's `setup()` method:

- `cmp_kind_text` for the kind text (default: Text)
- `highlight_group` for the highlight group (default: CmpItemKindText)

This makes it possible to change the icon and color of the labels of completions provided by this source.

Fixes https://github.com/Gelio/cmp-natdat/issues/2

## Example

```lua
{
    "Gelio/cmp-natdat",
    config = function()
        require("cmp_natdat").setup({
            cmp_kind_text = "NatDat",
            highlight_group = "Red",
        })
    end,
}
```

![cmp-natdat completions in the nvim-cmp popup are labeled "NatDat" in red](https://github.com/Gelio/cmp-natdat/assets/889383/52730df8-e355-4f4e-842f-d4cb283fbb12)

and if we additionally configure [lspkind.nvim](https://github.com/onsails/lspkind.nvim) to show the calendar icon for this completion kind:

```lua
require("lspkind").init({
    symbol_map = {
        NatDat = "📅",
    },
})
```

![cmp-natdat completions use the calendar icon](https://github.com/Gelio/cmp-natdat/assets/889383/9bf4df4c-fdfb-44d7-a60f-2a8370c94935)

